### PR TITLE
Add 'active' class on current route

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ cache:
 
 env:
   - EMBER_TRY_SCENARIO=default
-  - EMBER_TRY_SCENARIO=ember-1.10
   - EMBER_TRY_SCENARIO=ember-1.11
   - EMBER_TRY_SCENARIO=ember-1.12
   - EMBER_TRY_SCENARIO=ember-1.13
@@ -19,6 +18,10 @@ env:
   - EMBER_TRY_SCENARIO=ember-2.1
   - EMBER_TRY_SCENARIO=ember-2.2
   - EMBER_TRY_SCENARIO=ember-2.3
+  - EMBER_TRY_SCENARIO=ember-2.4
+  - EMBER_TRY_SCENARIO=ember-2.5
+  - EMBER_TRY_SCENARIO=ember-2.6
+  - EMBER_TRY_SCENARIO=ember-2.7
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 Demo: [http://asross.github.io/dynamic-link/](http://asross.github.io/dynamic-link/)
 
-`dynamic-link` is an alternative to the `link-to` helper that provides more flexibility for dynamic parameters, including actions and literal hrefs.
+`dynamic-link` is an alternative to the `link-to` helper that provides more
+flexibility for dynamic parameters, including actions and literal hrefs.
 
 ## Installation
 
@@ -15,11 +16,15 @@ ember install dynamic-link
 
 ## Usage
 
-`dynamic-link` accepts parameters for `route`, `action`, `model`, `models`, `queryParams`, and `href`. It uses these parameters to generate the `<a>` tag's `href` and determine what happens when it is clicked.
+`dynamic-link` accepts parameters for `route`, `action`, `model`, `models`,
+`queryParams`, and `href`. It uses these parameters to generate the `<a>` tag's
+`href` and determine what happens when it is clicked.
 
-It also supports the html attributes `title`, `rel`, `target`, and `class` either directly or via `className`.
+It also supports the html attributes `title`, `rel`, `target`, and `class`
+either directly or via `className`.
 
-This is helpful, for example, when implementing breadcrumbs or navbars, with lists of links that freely mix Ember routes, actions, and literal hrefs:
+This is helpful, for example, when implementing breadcrumbs or navbars, with
+lists of links that freely mix Ember routes, actions, and literal hrefs:
 
 ```js
 // .js
@@ -79,11 +84,14 @@ if `currentUser` is present (with an `id` of 1), or else
 <a href='/sign_in?foo=bar'>Sign In</a>
 ```
 
-Clicking the route-based links will transition the route without refreshing the page, while clicking action links will bubble actions properly. Literal links will work normally.
+Clicking the route-based links will transition the route without refreshing the
+page, while clicking action links will bubble actions properly. Literal links
+will work normally.
 
 ### Passing Params Directly
 
-Note that in addition to being able to pass all of these parameters in via the `params` object, you can also pass them in directly:
+Note that in addition to being able to pass all of these parameters in via the
+`params` object, you can also pass them in directly:
 
 ```hbs
 {{dynamic-link route=someRoute model=someModel queryParams=someQueryParams}}
@@ -93,7 +101,8 @@ If any of the parameters are falsey, they will be ignored.
 
 ### Multiple Dynamic Segments
 
-You can use `dynamic-link` with multiple dynamic segments by passing in an array of models and/or ids to `model` or `params.model`. For example,
+You can use `dynamic-link` with multiple dynamic segments by passing in an
+array of models and/or ids to `model` or `params.model`. For example,
 
 ```js
 export default Ember.Controller.extend({
@@ -135,9 +144,17 @@ or just
 
 ### Active Class
 
-Route-based `dynamic-link`s have basic support for automatically adding the `'active'` class to the `<a>` tag if their parameters match the current route. You can customize the class name by passing a string to `activeClass` or `params.activeClass`, and you can also set a default for all `dynamic-link`s by reopening the component and overriding `defaultActiveClass`. If you don't wish to apply any class at all, you can pass `activeClass=false` for a particular link or `defaultActiveClass=false` on the component to disable this behavior for all of them.
+Route-based `dynamic-link`s have basic support for automatically adding the
+`'active'` class to the `<a>` tag if their parameters match the current route.
+You can customize the class name by passing a string to `activeClass` or
+`params.activeClass`, and you can also set a default for all `dynamic-link`s by
+reopening the component and overriding `defaultActiveClass`.
 
-If you want to customize how `dynamic-link` decides whether the active class should be added, you can pass a boolean or a computed property to `activeWhen` or `params.activeWhen`:
+If you don't wish to apply any class at all, you can pass `activeClass=false`
+to a particular link or set `defaultActiveClass: false` on the component.
+
+If you want to customize how `dynamic-link` decides when the active class
+should be added, you can pass a property to `activeWhen`/`params.activeWhen`:
 
 ```hbs
 {{#dynamic-link activeWhen=sortDescending activeClass='highlight' action=makeSortAscending}}
@@ -148,7 +165,7 @@ If you want to customize how `dynamic-link` decides whether the active class sho
 ## Running Tests
 
 * `git clone git@github.com:asross/dynamic-link.git`
-* `npm install`
+* `npm install && bower install`
 * `ember test`
 * `ember test --server`
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,18 @@ or just
 <a href="/photos/1/comments/new">Add Comment</a>
 ```
 
+### Active Class
+
+Route-based `dynamic-link`s have basic support for automatically adding the `'active'` class to the `<a>` tag if their parameters match the current route. You can customize the class name by passing a string to `activeClass` or `params.activeClass`, and you can also set a default for all `dynamic-link`s by reopening the component and overriding `defaultActiveClass`. If you don't wish to apply any class at all, you can pass `activeClass=false` for a particular link or `defaultActiveClass=false` on the component to disable this behavior for all of them.
+
+If you want to customize how `dynamic-link` decides whether the active class should be added, you can pass a boolean or a computed property to `activeWhen` or `params.activeWhen`:
+
+```hbs
+{{#dynamic-link activeWhen=sortDescending activeClass='highlight' action=makeSortAscending}}
+  Sort ascending
+{{/dynamic-link}}
+```
+
 ## Running Tests
 
 * `git clone git@github.com:asross/dynamic-link.git`

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -6,12 +6,6 @@ module.exports = {
       dependencies: { }
     },
     {
-      name: 'ember-1.10',
-      dependencies: {
-        'ember': '~1.10'
-      }
-    },
-    {
       name: 'ember-1.11',
       dependencies: {
         'ember': '~1.11'
@@ -51,6 +45,30 @@ module.exports = {
       name: 'ember-2.3',
       dependencies: {
         'ember': '~2.3'
+      }
+    },
+    {
+      name: 'ember-2.4',
+      dependencies: {
+        'ember': '~2.4'
+      }
+    },
+    {
+      name: 'ember-2.5',
+      dependencies: {
+        'ember': '~2.5'
+      }
+    },
+    {
+      name: 'ember-2.6',
+      dependencies: {
+        'ember': '~2.6'
+      }
+    },
+    {
+      name: 'ember-2.7',
+      dependencies: {
+        'ember': '~2.7'
       }
     },
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamic-link",
-  "version": "0.0.5",
+  "version": "0.1.0",
   "description": "Ember CLI addon for the dynamic-link component, a more flexible version of link-to.",
   "directories": {
     "doc": "doc",

--- a/package.json
+++ b/package.json
@@ -39,9 +39,10 @@
     "ember-cli-sri": "^1.2.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-data": "1.13.15",
+    "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
-    "ember-disable-prototype-extensions": "^1.0.0",
+    "ember-getowner-polyfill": "1.0.1",
     "ember-try": "~0.0.8"
   },
   "keywords": [

--- a/tests/integration/dynamic-link-test.js
+++ b/tests/integration/dynamic-link-test.js
@@ -109,3 +109,83 @@ test('dynamic link with actions', function(assert) {
     assert.equal(currentRouteName(), "index", "clicking on an action link should not change the route");
   });
 });
+
+test('dynamic link with activeWhen and activeClass', function(assert) {
+  visit('/');
+
+  andThen(function() {
+    controller.set('dynamicLinkParams', { route: 'photos', activeWhen: true, activeClass: 'hyperactive' });
+  });
+
+  andThen(function() {
+    assert.equal(find('#dynamic-link a').attr('class'), 'ember-view hyperactive', 'active link should have active class');
+  });
+
+  andThen(function() {
+    controller.set('dynamicLinkParams', { route: 'photos', activeWhen: true, activeClass: false });
+  });
+
+  andThen(function() {
+    assert.equal(find('#dynamic-link a').attr('class'), 'ember-view', 'active link with activeClass = false should not have class name');
+  });
+});
+
+test('dynamic link that autocomputes isActive from route', function(assert) {
+  visit('/');
+
+  andThen(function() {
+    controller.set('dynamicLinkParams', { route: 'photos' });
+  });
+
+  andThen(function() {
+    assert.equal(find('#dynamic-link a').attr('class'), 'ember-view', 'inactive link should not have active class');
+  });
+
+  click('#dynamic-link a');
+
+  andThen(function() {
+    assert.equal(currentRouteName(), 'photos.index', "clicking on the link should transition to the new route");
+    assert.equal(find('#dynamic-link a').attr('class'), 'ember-view active', 'active link should have active class');
+  });
+
+  andThen(function() {
+    controller.set('dynamicLinkParams', { route: 'photo', model: 1 });
+  });
+
+  andThen(function() {
+    assert.equal(find('#dynamic-link a').attr('class'), 'ember-view', 'inactive link should not have active class');
+  });
+
+  click('#dynamic-link a');
+
+  andThen(function() {
+    assert.equal(currentRouteName(), 'photo.index', "clicking on the link should transition to the new route");
+    assert.equal(find('#dynamic-link a').attr('class'), 'ember-view active', 'active link should have active class');
+  });
+
+  andThen(function() {
+    controller.set('dynamicLinkParams', { route: 'photo', model: 2 });
+  });
+
+  andThen(function() {
+    assert.equal(find('#dynamic-link a').attr('class'), 'ember-view', 'inactive link should not have active class');
+  });
+
+  andThen(function() {
+    controller.set('dynamicLinkParams', { route: 'photo.comment', model: [1, { id: 2 }] });
+  });
+
+  click('#dynamic-link a');
+
+  andThen(function() {
+    assert.equal(find('#dynamic-link a').attr('class'), 'ember-view active', 'active link should have active class');
+  });
+
+  andThen(function() {
+    controller.set('dynamicLinkParams', { route: 'photo.comment', model: [1, { id: 3 }] });
+  });
+
+  andThen(function() {
+    assert.equal(find('#dynamic-link a').attr('class'), 'ember-view', 'inactive link should not have active class');
+  });
+});


### PR DESCRIPTION
First pass at addressing https://github.com/asross/dynamic-link/issues/2.

Like other features of this component, the implementation here does both more and less than [Ember's implementation of `link-to`](https://github.com/emberjs/ember.js/blob/v2.7.0/packages/ember-htmlbars/lib/components/link-to.js). Here you can override the default current route behavior and pass a computed property to decide whether the link should be active, and you can also customize what class name gets applied when it is. But I didn't add temporary classes to show when the model is loading or when the route is transitioning in our out (which `link-to` supports).

Also updates the library to fix some deprecation warnings in later versions of Ember 2, and test in all versions so far. The activeClass updates didn't work with Ember 1.10, but I figure no one is really using that anymore, so I dropped it from the CI suite.