### PR TITLE
Changed click event hook to use preventDefault rather than return false

### DIFF
--- a/addon/components/dynamic-link.js
+++ b/addon/components/dynamic-link.js
@@ -73,24 +73,21 @@ export default Ember.Component.extend({
     }
   }),
 
-  // returning true from this method causes the default click behavior
-  // to apply. For ctrl-clicks and for basic literal hrefs, we should
-  // return true to preserve normal behavior. For actions and route
-  // transitions, we should return false because Ember will handle it.
+  // returning true to allow default click behavior to bubble up through
+  // the application. preventDefault is used to prevent route transitions
+  // and actions from refreshing the page.
   click: function(event) {
-    if (event.metaKey || event.ctrlKey) {
-      return true;
-    } else if (this.get('action')) {
-      this.performAction();
-      return false;
-    } else if (this.get('route')) {
-      this.transitionRoute();
-      return false;
-    } else {
-      return true;
+    if (!event.metaKey && !event.ctrlKey) {
+      if (this.get('action')) {
+        event.preventDefault();
+        this.performAction();
+      } else if (this.get('route')) {
+        event.preventDefault();
+        this.transitionRoute();
+      }
     }
-    // TODO: consider returning true if target="_blank",
-    // even if there is an action or route?
+
+    return true;
   },
 
   // bubble the action to wherever the link was added

--- a/addon/components/dynamic-link.js
+++ b/addon/components/dynamic-link.js
@@ -37,6 +37,11 @@ export default Ember.Component.extend({
     }
   }),
 
+  // You can control whether or not the click event bubbles up through the
+  // component by setting this property directly or by setting it in the
+  // params hash. If no value is set, all clicks will bubble by default.
+  bubbles: Ember.computed.alias('params.bubbles'),
+
   models: Ember.computed('model', function() {
     if (this.get('model') instanceof Array) {
       return this.get('model');
@@ -73,9 +78,9 @@ export default Ember.Component.extend({
     }
   }),
 
-  // returning true to allow default click behavior to bubble up through
-  // the application. preventDefault is used to prevent route transitions
-  // and actions from refreshing the page.
+  // Use prevent default to keep route transitions and actions from
+  // refreshing the page. Allows click behavior to bubble up if allowed
+  // by the bubbles property
   click: function(event) {
     if (!event.metaKey && !event.ctrlKey) {
       if (this.get('action')) {
@@ -87,7 +92,7 @@ export default Ember.Component.extend({
       }
     }
 
-    return true;
+    return typeof this.get('bubbles') !== 'undefined' ? this.get('bubbles') : true;
   },
 
   // bubble the action to wherever the link was added

--- a/tests/dummy/app/components/test-container.js
+++ b/tests/dummy/app/components/test-container.js
@@ -1,0 +1,13 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  click() {
+    this.set('bubbles', true);
+  },
+
+  actions: {
+    toggleSomething: function() {
+      this.set('something', !this.get('something'));
+    }
+  }
+});

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -3,9 +3,5 @@ import Ember from 'ember';
 export default Ember.Controller.extend({
   dynamicLinkParams: {},
   something: false,
-  actions: {
-    toggleSomething: function() {
-      this.set('something', !this.get('something'));
-    }
-  }
+  bubbles: false
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -2,6 +2,4 @@
 
 {{outlet}}
 
-<div id="dynamic-link">
-  {{dynamic-link params=dynamicLinkParams}}
-</div>
+{{test-container id="dynamic-link" dynamicLinkParams=dynamicLinkParams something=something bubbles=bubbles}}

--- a/tests/dummy/app/templates/components/test-container.hbs
+++ b/tests/dummy/app/templates/components/test-container.hbs
@@ -1,0 +1,1 @@
+{{dynamic-link params=dynamicLinkParams}}

--- a/tests/integration/dynamic-link-test.js
+++ b/tests/integration/dynamic-link-test.js
@@ -189,3 +189,24 @@ test('dynamic link that autocomputes isActive from route', function(assert) {
     assert.equal(find('#dynamic-link a').attr('class'), 'ember-view', 'inactive link should not have active class');
   });
 });
+
+test('dynamic link that sets bubbles param', function(assert) {
+  visit('/');
+
+  click('#dynamic-link a');
+
+  andThen(function() {
+    assert.equal(controller.get('bubbles'), true, 'default setting allows click to bubble');
+  });
+
+  andThen(function() {
+    controller.set('bubbles', false);
+    controller.set('dynamicLinkParams', { bubbles: false });
+  });
+
+  click('#dynamic-link a');
+
+  andThen(function() {
+    assert.equal(controller.get('bubbles'), false, 'setting bubbles param to false stops click propagation');
+  });
+});


### PR DESCRIPTION
I have a use case where I'm using links in a dropdown menu that relies on the clicks bubbling up to the menu to tell it when to close the menu. Returning false in the click event hook was preventing my menu from closing when I used a route transition or action in the dynamic link. My solution is to use preventDefault rather than return false to keep the default anchor behavior from activating and to also let the click bubble up whenever the anchor is clicked.

This also seems to fill the use case in your TODO so I removed it.