### PR TITLE
Use routing service

### DIFF
--- a/addon/components/dynamic-link.js
+++ b/addon/components/dynamic-link.js
@@ -84,7 +84,7 @@ export default Ember.Component.extend({
       if (this.get('_routing')) {
         return this.get('_routing').generateURL(...this.get('routingArguments'));
       } else {
-        return this.get('_router').generateURL(...this.get('routeArguments'));
+        return this.get('_router').generate(...this.get('routeArguments'));
       }
     } else {
       return '#';

--- a/tests/integration/dynamic-link-test.js
+++ b/tests/integration/dynamic-link-test.js
@@ -118,7 +118,7 @@ test('dynamic link with activeWhen and activeClass', function(assert) {
   });
 
   andThen(function() {
-    assert.equal(find('#dynamic-link a').attr('class'), 'ember-view hyperactive', 'active link should have active class');
+    assert.ok(find('#dynamic-link a').hasClass('hyperactive'), 'active link should have active class');
   });
 
   andThen(function() {
@@ -126,7 +126,7 @@ test('dynamic link with activeWhen and activeClass', function(assert) {
   });
 
   andThen(function() {
-    assert.equal(find('#dynamic-link a').attr('class'), 'ember-view', 'active link with activeClass = false should not have class name');
+    assert.notOk(find('#dynamic-link a').hasClass('hyperactive'), 'active link with activeClass = false should not have class name');
   });
 });
 
@@ -138,14 +138,14 @@ test('dynamic link that autocomputes isActive from route', function(assert) {
   });
 
   andThen(function() {
-    assert.equal(find('#dynamic-link a').attr('class'), 'ember-view', 'inactive link should not have active class');
+    assert.notOk(find('#dynamic-link a').hasClass('active'), 'inactive link should not have active class');
   });
 
   click('#dynamic-link a');
 
   andThen(function() {
     assert.equal(currentRouteName(), 'photos.index', "clicking on the link should transition to the new route");
-    assert.equal(find('#dynamic-link a').attr('class'), 'ember-view active', 'active link should have active class');
+    assert.ok(find('#dynamic-link a').hasClass('active'), 'active link should have active class');
   });
 
   andThen(function() {
@@ -153,14 +153,14 @@ test('dynamic link that autocomputes isActive from route', function(assert) {
   });
 
   andThen(function() {
-    assert.equal(find('#dynamic-link a').attr('class'), 'ember-view', 'inactive link should not have active class');
+    assert.notOk(find('#dynamic-link a').hasClass('active'), 'inactive link should not have active class');
   });
 
   click('#dynamic-link a');
 
   andThen(function() {
     assert.equal(currentRouteName(), 'photo.index', "clicking on the link should transition to the new route");
-    assert.equal(find('#dynamic-link a').attr('class'), 'ember-view active', 'active link should have active class');
+    assert.ok(find('#dynamic-link a').hasClass('active'), 'active link should have active class');
   });
 
   andThen(function() {
@@ -168,7 +168,7 @@ test('dynamic link that autocomputes isActive from route', function(assert) {
   });
 
   andThen(function() {
-    assert.equal(find('#dynamic-link a').attr('class'), 'ember-view', 'inactive link should not have active class');
+    assert.notOk(find('#dynamic-link a').hasClass('active'), 'inactive link should not have active class');
   });
 
   andThen(function() {
@@ -178,7 +178,7 @@ test('dynamic link that autocomputes isActive from route', function(assert) {
   click('#dynamic-link a');
 
   andThen(function() {
-    assert.equal(find('#dynamic-link a').attr('class'), 'ember-view active', 'active link should have active class');
+    assert.ok(find('#dynamic-link a').hasClass('active'), 'active link should have active class');
   });
 
   andThen(function() {
@@ -186,7 +186,7 @@ test('dynamic link that autocomputes isActive from route', function(assert) {
   });
 
   andThen(function() {
-    assert.equal(find('#dynamic-link a').attr('class'), 'ember-view', 'inactive link should not have active class');
+    assert.notOk(find('#dynamic-link a').hasClass('active'), 'inactive link should not have active class');
   });
 });
 


### PR DESCRIPTION
Where ever I have used the `dynamic-link` in my own components (and using real routes as links), all those component integration tests were failing. This was because probably the Router is not properly initialized in an integration test. (it was calling `generate` on `Router.router` being `undefined`).

As there were no problems like this with the normal `link-to` component, I looked at it, and they were using the (still private) routing service (I think introduced wth Ember 1.13) instead of directly calling the Router.

I updated the dynamic-link component to use that also if available, and gone were the exceptions...

Also updated some tests as beginning with 2.10 the order of classes was changed, the tests were to brittle in that regard...