### PR TITLE
Fix for getowner polyfill import deprecation

### DIFF
--- a/addon/components/dynamic-link.js
+++ b/addon/components/dynamic-link.js
@@ -1,5 +1,4 @@
 import Ember from 'ember';
-import getOwner from 'ember-getowner-polyfill';
 
 export default Ember.Component.extend({
   tagName: 'a',
@@ -117,7 +116,7 @@ export default Ember.Component.extend({
   },
 
   _route: Ember.computed(function() {
-    return getOwner(this).lookup('route:application');
+    return Ember.getOwner(this).lookup('route:application');
   }),
 
   _router: Ember.computed.readOnly('_route.router'),

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
-    "ember-getowner-polyfill": "1.0.1",
+    "ember-getowner-polyfill": "1.2.2",
     "ember-try": "~0.0.8"
   },
   "keywords": [


### PR DESCRIPTION
Fix for the deprecation message below. I believe this was all that was needed. Cheers

ember-getowner-polyfill is now a true polyfill. Use Ember.getOwner directly instead of importing from ember-getowner-polyfill [deprecation id: ember-getowner-polyfill.import]