### PR TITLE
Remove ember-getowner-polyfill dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,7 @@
     "link-to"
   ],
   "dependencies": {
-    "ember-cli-babel": "^6.0.0",
-    "ember-getowner-polyfill": "^1.2.3"
+    "ember-cli-babel": "^6.0.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "link-to"
   ],
   "dependencies": {
-    "ember-cli-babel": "^6.0.0"
+    "ember-cli-babel": "^6.0.0",
+    "ember-getowner-polyfill": "^2.2.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
Since pull #7  it is not need anymore.