### PR TITLE
Renamed router to _router as per deprecration message

### DIFF
--- a/addon/components/dynamic-link.js
+++ b/addon/components/dynamic-link.js
@@ -119,7 +119,9 @@ export default Ember.Component.extend({
     return Ember.getOwner(this).lookup('route:application');
   }),
 
-  _router: Ember.computed.readOnly('_route.router'),
+  _router: Ember.computed('_route._router', '_route.router', function() {
+    return this.get('_route._router') || this.get('_route.router');
+  }),
 
   _routing: Ember.inject.service(),
 


### PR DESCRIPTION
A fix for this deprecation:

DEPRECATION: Route#router is an intimate API that has been renamed to Route#_router. However you might want to consider using the router service [deprecation id: ember-routing.route-router] See https://emberjs.com/deprecations/v3.x#toc_ember-routing-route-router for more details.

It seems that rewriting the code to use the methods available in the router service may be a more future proof fix for this problem. For now though I made the less invasive of the two choices and changed the name of the property.