### PR TITLE
Deprecation fix for using targetObject

### DIFF
--- a/addon/components/dynamic-link.js
+++ b/addon/components/dynamic-link.js
@@ -109,7 +109,7 @@ export default Ember.Component.extend({
 
   // bubble the action to wherever the link was added
   performAction: function() {
-    var target = this.get('targetObject') || this.get('_targetObject');
+    var target = this.get('_targetObject') || this.get('targetObject');
     if (target) {
       target.send(this.get('action'));
     }


### PR DESCRIPTION
Wasn't sure if I should change the readme at all to mention linkTarget.